### PR TITLE
修復分佈式訓練時資料不平衡的問題

### DIFF
--- a/src/llm_training/data/base_datamodule.py
+++ b/src/llm_training/data/base_datamodule.py
@@ -66,9 +66,7 @@ class BaseDataModule(L.LightningDataModule):
         if split == 'train':
             dataloader_class = ResumableDataLoader
             dataloader_kwargs['shuffle'] = True
-
-            if self.trainer is not None and self.trainer.distributed_sampler_kwargs is not None:
-                dataloader_kwargs.update(self.trainer.distributed_sampler_kwargs)
+            dataloader_kwargs['trainer'] = self.trainer
 
         return dataloader_class(**dataloader_kwargs)
     

--- a/src/llm_training/data/resumable_dataloader.py
+++ b/src/llm_training/data/resumable_dataloader.py
@@ -1,136 +1,56 @@
-from typing import Any, Iterator, Protocol, Sized
+from typing import Any, Iterable, Iterator
 
-import torch
-import torch.distributed
-from torch.utils.data import (DataLoader, Dataset, DistributedSampler,
-                              RandomSampler, SequentialSampler)
-
-
-class ResumableSequentialSampler(SequentialSampler):
-    def __init__(self, data_source: Sized) -> None:
-        super().__init__(data_source)
-
-        self.used_indices = set()
-
-    def __iter__(self) -> Iterator[int]:
-        for i, index in enumerate(super().__iter__()):
-            is_used = index in self.used_indices
-
-            self.used_indices.add(index)
-
-            if i + 1 == len(self.data_source):
-                self.used_indices.clear()
-            
-            if not is_used:
-                yield index
+from lightning import Trainer
+from torch.utils.data import BatchSampler, DataLoader
+from torch.utils.data.sampler import Sampler
 
 
-class ResumableRandomSampler(RandomSampler):
+class ResumableBatchSampler(BatchSampler):
     def __init__(
         self,
-        data_source: Sized,
-        replacement: bool = False,
-        num_samples: int | None = None,
-        generator: torch.Generator | None = None
+        sampler: Sampler[int] | Iterable[int],
+        batch_size: int,
+        drop_last: bool,
+        trainer: Trainer | None = None
     ) -> None:
-        generator = generator or torch.Generator().manual_seed(0)
-
-        super().__init__(data_source, replacement, num_samples, generator)
-
-        self.used_indices = set()
-
-    def __iter__(self) -> Iterator[int]:
-        for i, index in enumerate(super().__iter__()):
-            is_used = index in self.used_indices
-
-            self.used_indices.add(index)
-
-            if i + 1 == self.num_samples:
-                self.used_indices.clear()
-            
-            if not is_used:
-                yield index
-
-
-class ResumableDistributedSampler(DistributedSampler):
-    def __init__(
-        self,
-        dataset: Dataset,
-        num_replicas: int | None = None,
-        rank: int | None = None,
-        shuffle: bool = True,
-        seed: int = 0,
-        drop_last: bool = False,
-    ) -> None:
-        super().__init__(dataset, num_replicas, rank, shuffle, seed, drop_last)
+        super().__init__(sampler, batch_size, drop_last)
         
-        self.used_indices = set()
+        self.trainer = trainer
 
-    def __iter__(self) -> Iterator[int]:
-        for i, index in enumerate(super().__iter__()):
-            is_used = index in self.used_indices
-            is_padding = i >= (len(self.dataset) // self.num_replicas)
+    def __iter__(self) -> Iterator[list[int]]:
+        for i, indices in enumerate(super().__iter__()):
+            if self.trainer is not None and i < self.trainer.fit_loop.batch_idx:
+                continue
 
-            if not is_padding:
-                self.used_indices.add(index)
-
-            if i + 1 == self.num_samples:
-                self.used_indices.clear()
-            
-            if not is_used or is_padding:
-                yield index
-
-
-class ResumableSamplerProtocol(Protocol):
-    used_indices: set[int]
+            yield indices
 
 
 class ResumableDataLoader(DataLoader):
-    sampler: ResumableSamplerProtocol
-
     def __init__(
         self,
-        dataset: Dataset,
-        shuffle: bool = True,
-        sampler: None = None,
-        num_replicas: int | None = None,
-        rank: int | None = None,
-        generator: torch.Generator | None = None,
+        trainer: Trainer | None = None,
         *args,
         **kwargs
     ):
-        assert sampler is None, f"To use {self.__class__.__name__}, `sampler` must be None."
+        self.trainer = trainer
 
-        if num_replicas is not None and rank is not None:
-            kwargs['sampler'] = ResumableDistributedSampler(
-                dataset,
-                num_replicas=num_replicas,
-                rank=rank,
-                shuffle=shuffle
+        super().__init__(*args, **kwargs)
+
+    def __setattr__(self, attr: str, val: Any):
+        if attr == 'batch_sampler':
+            assert isinstance(val, BatchSampler)
+
+            val = ResumableBatchSampler(
+                sampler=val.sampler,
+                batch_size=val.batch_size,
+                drop_last=val.drop_last,
+                trainer=self.trainer
             )
-        elif shuffle:
-            kwargs['sampler'] = ResumableRandomSampler(dataset, generator=generator)
-        else:
-            kwargs['sampler'] = ResumableSequentialSampler(dataset)
-
-        super().__init__(dataset, *args, **kwargs)
-
-    def sync_state(self) -> None:
-        if not torch.distributed.is_initialized():
-            return
         
-        # sync used_indices
-        l = [None] * torch.distributed.get_world_size()
-        torch.distributed.all_gather_object(l, self.sampler.used_indices)
-        self.sampler.used_indices.clear()
-        self.sampler.used_indices.update(y for x in l for y in x)
+        return super().__setattr__(attr, val)
 
     def state_dict(self) -> dict[str, Any]:
-        self.sync_state()
-
-        return {
-            'sampler.used_indices': self.sampler.used_indices
-        }
+        return {}
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        self.sampler.used_indices = state_dict['sampler.used_indices']
+        ...


### PR DESCRIPTION
`ResumableDistributedSampler` 在某些情況下每個 rank 的資料量會不平衡，進而導致訓練卡住
#7 有一部份情況可能由此造成，但不確定是否還有其他原因

改用 `BatchSampler` 及 `batch_idx` 來恢復訓練進度
